### PR TITLE
Fixed error handling and updated version of gfwr in useragent

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gfwr
 Title: Interactions with GFW APIs providing data tibbles
-Version: 0.0.0.9000
+Version: 1.1.0
 Authors@R: c(
     person("Tyler", "Clavelle", , "tyler@globalfishingwatch.org", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-2155-2459")),

--- a/R/utils.R
+++ b/R/utils.R
@@ -50,11 +50,11 @@ make_datetime <- function(x) {
 #' @return
 gist_error_body <- function(resp) {
   body <- httr2::resp_body_json(resp)
-  message <- body$message
-  if(length(message) > 1){
-    message <- purrr::map_chr(message, purrr::pluck, 'detail')
+  messages <- body$messages
+  if(length(messages[[1]]) > 1){
+    messages <- purrr::map_chr(messages, purrr::pluck, 'detail')
   }
-  message
+  messages
 }
 
 #' Pagination function for GFW API calls
@@ -75,7 +75,7 @@ paginate <- function(endpoint, key){
                                              key,
                                              sep = " "),
                        `Content-Type` = 'application/json') %>%
-    httr2::req_user_agent("gfwr/1.0.0 (https://github.com/GlobalFishingWatch/gfwr)") %>%
+    httr2::req_user_agent("gfwr/1.1.0 (https://github.com/GlobalFishingWatch/gfwr)") %>%
     httr2::req_error(body = gist_error_body) %>%
     httr2::req_perform() %>%
     httr2::resp_body_json()
@@ -101,7 +101,7 @@ paginate <- function(endpoint, key){
                                                  key,
                                                  sep = " "),
                            `Content-Type` = 'application/json') %>%
-        httr2::req_user_agent("gfwr/1.0.0 (https://github.com/GlobalFishingWatch/gfwr)") %>%
+        httr2::req_user_agent("gfwr/1.1.0 (https://github.com/GlobalFishingWatch/gfwr)") %>%
         httr2::req_error(body = gist_error_body) %>%
         httr2::req_perform() %>%
         httr2::resp_body_json()
@@ -139,7 +139,7 @@ get_region_id <- function(region_name, region_source = 'eez', key) {
 
   result <- get_endpoint(dataset_type = region_source) %>%
     httr2::req_headers(Authorization = paste("Bearer", key, sep = " ")) %>%
-    httr2::req_user_agent("gfwr/1.0.0 (https://github.com/GlobalFishingWatch/gfwr)") %>%
+    httr2::req_user_agent("gfwr/1.1.0 (https://github.com/GlobalFishingWatch/gfwr)") %>%
     httr2::req_error(body = gist_error_body) %>%
     httr2::req_perform(.) %>%
     httr2::resp_body_json(.) %>%

--- a/man/gist_error_body.Rd
+++ b/man/gist_error_body.Rd
@@ -8,9 +8,6 @@ Taken from httr2 docs: https://httr2.r-lib.org/articles/wrapping-apis.html#sendi
 \usage{
 gist_error_body(resp)
 }
-\value{
-
-}
 \description{
 Helper function to parse error message data
 and display appropriately to user

--- a/man/make_char.Rd
+++ b/man/make_char.Rd
@@ -6,9 +6,6 @@
 \usage{
 make_char(col)
 }
-\value{
-
-}
 \description{
 Basic function to make length 1 lists into characters
 }

--- a/man/make_datetime.Rd
+++ b/man/make_datetime.Rd
@@ -6,9 +6,6 @@
 \usage{
 make_datetime(x)
 }
-\value{
-
-}
 \description{
 Helper function to convert datetime responses
 }

--- a/man/paginate.Rd
+++ b/man/paginate.Rd
@@ -6,9 +6,6 @@
 \usage{
 paginate(endpoint, key)
 }
-\value{
-
-}
 \description{
 Pagination function for GFW API calls
 }


### PR DESCRIPTION
PR to address #83 and #87 by updating the error handling in `gist_error_body` to use the new format from the API @natemiller @rociojoo.

Also updates the version number in the `DESCRIPTION` and in the `useragent` sent with the API request.