### PR TITLE
add filters to get_raster

### DIFF
--- a/R/get_raster.R
+++ b/R/get_raster.R
@@ -25,6 +25,7 @@
 get_raster <- function(spatial_resolution = NULL,
                        temporal_resolution = NULL,
                        group_by = NULL,
+                       filter_by = NULL,
                        date_range = NULL,
                        region = NULL,
                        region_source = NULL,
@@ -35,12 +36,11 @@ get_raster <- function(spatial_resolution = NULL,
     dataset_type = "raster",
     `spatial-resolution` = spatial_resolution,
     `temporal-resolution` = temporal_resolution,
+    `filters[0]` = filter_by,
     `group-by` = group_by,
     `date-range` = date_range,
     format = 'csv'
   )
-
-
 
   if (region_source == 'mpa' & is.numeric(region)) {
     region = rjson::toJSON(list(region = list(dataset = 'public-mpa-all',


### PR DESCRIPTION
This PR addresses issue #97  allowing 4wings rasters to be filtered by geartype or flag. This involves adding a `filter_by` parameter to the `get_raster` function.

Examples:

Filter by flag
```
key = get_auth()

code_eez <- get_region_id(region_name = 'CIV', region_source = 'eez', key = key)

get_raster(spatial_resolution = 'low',
            temporal_resolution = 'yearly',
            group_by = 'flag',
            date_range = '2021-01-01,2021-10-01', 
            filter_by = "flag IN ('SLV')",
            region = code_eez$id,
            region_source = 'eez',
            key = key)
```

Filter by geartype
```
key = get_auth()

code_eez <- get_region_id(region_name = 'CIV', region_source = 'eez', key = key)

get_raster(spatial_resolution = 'low',
            temporal_resolution = 'yearly',
            group_by = 'flag',
            date_range = '2021-01-01,2021-10-01', 
            filter_by = "geartype in ('tuna_purse_seines','driftnets')",
            region = code_eez$id,
            region_source = 'eez',
            key = key)
```