### PR TITLE
updating get_raster for V3

### DIFF
--- a/R/get_endpoint.R
+++ b/R/get_endpoint.R
@@ -50,17 +50,17 @@ get_endpoint <- function(dataset_type,...){
   } else if (dataset_type == "eez") {
 
     endpoint <- base %>%
-      httr2::req_url_path_append("datasets/public-eez-areas/user-context-layers")
+      httr2::req_url_path_append("datasets/public-eez-areas/context-layers")
 
   } else if (dataset_type == "mpa") {
 
     endpoint <- base %>%
-      httr2::req_url_path_append("datasets/public-mpa-all/user-context-layers")
+      httr2::req_url_path_append("datasets/public-mpa-all/context-layers")
 
   } else if (dataset_type == "rfmo") {
 
     endpoint <- base %>%
-      httr2::req_url_path_append("datasets/public-rfmo/user-context-layers")
+      httr2::req_url_path_append("datasets/public-rfmo/context-layers")
 
   } else {
     stop("Select valid dataset type")

--- a/R/get_endpoint.R
+++ b/R/get_endpoint.R
@@ -28,7 +28,7 @@ get_endpoint <- function(dataset_type,...){
   base <- httr2::request("https://gateway.api.globalfishingwatch.org/v3/")
 
   # Get dataset ID for selected API
-  if (!dataset_type %in% c('eez', 'mpa', 'rfmo')) {
+  if (!dataset_type %in% c('EEZ', 'MPA', 'RFMO')) {
     dataset <- api_datasets[[dataset_type]]
   }
 
@@ -47,17 +47,17 @@ get_endpoint <- function(dataset_type,...){
       httr2::req_url_path_append('4wings/report') %>%
       httr2::req_url_query(!!!args)
 
-  } else if (dataset_type == "eez") {
+  } else if (dataset_type == "EEZ") {
 
     endpoint <- base %>%
       httr2::req_url_path_append("datasets/public-eez-areas/context-layers")
 
-  } else if (dataset_type == "mpa") {
+  } else if (dataset_type == "MPA") {
 
     endpoint <- base %>%
       httr2::req_url_path_append("datasets/public-mpa-all/context-layers")
 
-  } else if (dataset_type == "rfmo") {
+  } else if (dataset_type == "RFMO") {
 
     endpoint <- base %>%
       httr2::req_url_path_append("datasets/public-rfmo/context-layers")

--- a/R/get_raster.R
+++ b/R/get_raster.R
@@ -43,17 +43,17 @@ get_raster <- function(spatial_resolution = NULL,
     format = 'CSV'
   )
 
-  if (region_source == 'mpa' & is.numeric(region)) {
+  if (region_source == 'MPA' & is.numeric(region)) {
     region = rjson::toJSON(list(region = list(dataset = 'public-mpa-all',
                                              id = region)))
 
-  } else if (region_source == 'eez' & is.numeric(region)) {
+  } else if (region_source == 'EEZ' & is.numeric(region)) {
     region = rjson::toJSON(list(region = list(dataset = 'public-eez-areas',
                                              id = region)))
-  } else if (region_source == 'rfmo' & is.character(region)) {
+  } else if (region_source == 'RFMO' & is.character(region)) {
     region = rjson::toJSON(list(region = list(dataset = 'public-rfmo',
                                               id = region)))
-  } else if (region_source == 'user_json' & is.character(region)) {
+  } else if (region_source == 'USER_JSON' & is.character(region)) {
     region
   } else {
     stop('region source and region format do not match')

--- a/R/get_raster.R
+++ b/R/get_raster.R
@@ -40,7 +40,7 @@ get_raster <- function(spatial_resolution = NULL,
     `filters[0]` = filter_by,
     `group-by` = group_by,
     `date-range` = date_range,
-    format = 'csv'
+    format = 'CSV'
   )
 
   if (region_source == 'mpa' & is.numeric(region)) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -130,7 +130,7 @@ gfw_api_request <- function(endpoint, key) {
 #' @importFrom httr2 resp_body_json
 #'
 
-get_region_id <- function(region_name, region_source = 'eez', key) {
+get_region_id <- function(region_name, region_source = 'EEZ', key) {
 
   result <- get_endpoint(dataset_type = region_source) %>%
     httr2::req_headers(Authorization = paste("Bearer", key, sep = " ")) %>%
@@ -141,35 +141,35 @@ get_region_id <- function(region_name, region_source = 'eez', key) {
     dplyr::bind_rows()
 
   # EEZ names
-  if (region_source == "eez" & is.character(region_name)) {
+  if (region_source == "EEZ" & is.character(region_name)) {
     result %>%
       dplyr::filter(agrepl(region_name, .$label) | agrepl(paste0('^',region_name), .$iso3)) %>%
       dplyr::mutate(id = as.numeric(id))
   }
   # EEZ ids
-  else if (region_source == "eez" & is.numeric(region_name)) {
+  else if (region_source == "EEZ" & is.numeric(region_name)) {
     result %>%
       dplyr::filter(id == {{ region_name }})
   }
   # MPA names
-  else if (region_source == "mpa" & is.character(region_name)) {
+  else if (region_source == "MPA" & is.character(region_name)) {
     result %>%
       dplyr::filter(agrepl(region_name, .$label)) %>%
       dplyr::mutate(id = as.numeric(id))
   }
   # MPA ids
-  else if (region_source == "mpa" & is.numeric(region_name)) {
+  else if (region_source == "MPA" & is.numeric(region_name)) {
     result %>%
       dplyr::filter(id == {{ region_name }})
   }
   # RFMO names
-  else if (region_source == "rfmo" & is.character(region_name)) {
+  else if (region_source == "RFMO" & is.character(region_name)) {
     result %>%
       dplyr::filter(agrepl(region_name, .$label)) %>%
       dplyr::mutate(id = as.numeric(id))
   }
   # RFMO ids
-  else if (region_source == "rfmo" & is.numeric(region_name)) {
+  else if (region_source == "RFMO" & is.numeric(region_name)) {
     result %>%
       dplyr::filter(id == {{ region_name }})
   } else {

--- a/README.Rmd
+++ b/README.Rmd
@@ -231,12 +231,12 @@ get_event(event_type='fishing',
 The `get_raster` function gets a raster from the [4Wings API](https://globalfishingwatch.org/our-apis/documentation#map-visualization-4wings-api) and converts the 
 response to a data frame. In order to use it, you should specify:
 
-* The spatial resolution, which can be `low` (0.1 degree) or `high` (0.01 degree)
-* The temporal resolution, which can be `daily`, `monthly`, or `yearly`.
-* The variable to group by: `vessel_id`, `flag`, `gearType`, or `flagAndGearType`
-* The date range `note: this must be one (1) year or less`
+* The spatial resolution, which can be `LOW` (0.1 degree) or `HIGH` (0.01 degree)
+* The temporal resolution, which can be `HOURLY`, `DAILY`, `MONTHLY`, `YEARLY` or `ENTIRE`.
+* The variable to group by: `FLAG`, `GEARTYPE`, `FLAGANDGEARTYPE`, `MMSI` or `VESSEL_ID`
+* The date range `note: this must be 366 days or less`
 * The `geojson` region or region code (such as an EEZ code) to filter the raster
-* The source for the specified region (currently, `eez`, `mpa`, or `user_json`)
+* The source for the specified region (currently, `EEZ`, `MPA`, `RFMO` or `USER_JSON`)
 
 
 ### Examples
@@ -249,12 +249,12 @@ Here's an example where we enter the geojson data manually:
 region_json = '{"geojson":{"type":"Polygon","coordinates":[[[-76.11328125,-26.273714024406416],[-76.201171875,-26.980828590472093],[-76.376953125,-27.527758206861883],[-76.81640625,-28.30438068296276],[-77.255859375,-28.767659105691244],[-77.87109375,-29.152161283318918],[-78.486328125,-29.45873118535532],[-79.189453125,-29.61167011519739],[-79.892578125,-29.6880527498568],[-80.595703125,-29.61167011519739],[-81.5625,-29.382175075145277],[-82.177734375,-29.07537517955835],[-82.705078125,-28.6905876542507],[-83.232421875,-28.071980301779845],[-83.49609375,-27.683528083787756],[-83.759765625,-26.980828590472093],[-83.84765625,-26.35249785815401],[-83.759765625,-25.64152637306576],[-83.583984375,-25.16517336866393],[-83.232421875,-24.447149589730827],[-82.705078125,-23.966175871265037],[-82.177734375,-23.483400654325635],[-81.5625,-23.241346102386117],[-80.859375,-22.998851594142906],[-80.15625,-22.917922936146027],[-79.453125,-22.998851594142906],[-78.662109375,-23.1605633090483],[-78.134765625,-23.40276490540795],[-77.431640625,-23.885837699861995],[-76.9921875,-24.28702686537642],[-76.552734375,-24.846565348219727],[-76.2890625,-25.48295117535531],[-76.11328125,-26.273714024406416]]]}}'
 
 get_raster(
-  spatial_resolution = 'low',
-  temporal_resolution = 'yearly',
-  group_by = 'flag',
+  spatial_resolution = 'LOW',
+  temporal_resolution = 'YEARLY',
+  group_by = 'FLAG',
   date_range = '2021-01-01,2021-12-31',
   region = region_json,
-  region_source = 'user_json',
+  region_source = 'USER_JSON',
   key = key
   )
 ```
@@ -262,18 +262,18 @@ get_raster(
 If you want raster data from a particular EEZ, you can use the `get_region_id` 
 function to get the EEZ id, enter that code in the `region` argument
 of `get_raster` instead of the geojson data (ensuring you specify the `region_source`
-as `'eez'`:
+as `'EEZ'`:
 
 ```{r example_map_2, eval=F}
 # use EEZ function to get EEZ code of Cote d'Ivoire
-code_eez <- get_region_id(region_name = 'CIV', region_source = 'eez', key = key)
+code_eez <- get_region_id(region_name = 'CIV', region_source = 'EEZ', key = key)
 
-get_raster(spatial_resolution = 'low',
-           temporal_resolution = 'yearly',
-           group_by = 'flag',
+get_raster(spatial_resolution = 'LOW',
+           temporal_resolution = 'YEARLY',
+           group_by = 'FLAG',
            date_range = '2021-01-01,2021-10-01',
            region = code_eez$id,
-           region_source = 'eez',
+           region_source = 'EEZ',
            key = key)
 ```
 
@@ -281,15 +281,15 @@ You could search for just one word in the name of the EEZ and then decide which
 one you want:
 
 ```{r example_map_3, eval=T}
-(get_region_id(region_name = 'France', region_source = 'eez', key = key))
+(get_region_id(region_name = 'France', region_source = 'EEZ', key = key))
 
 # Let's say we're interested in the French Exclusive Economic Zone, 5677
-get_raster(spatial_resolution = 'low',
-           temporal_resolution = 'yearly',
-           group_by = 'flag',
+get_raster(spatial_resolution = 'LOW',
+           temporal_resolution = 'YEARLY',
+           group_by = 'FLAG',
            date_range = '2021-01-01,2021-10-01',
            region = 5677,
-           region_source = 'eez',
+           region_source = 'EEZ',
            key = key)
 ```
 
@@ -299,14 +299,14 @@ in this case the Phoenix Island Protected Area (PIPA)
 
 ```{r example_map_4, eval=F}
 # use region id function to get MPA code of Phoenix Island Protected Area
-code_mpa <- get_region_id(region_name = 'Phoenix', region_source = 'mpa', key = key)
+code_mpa <- get_region_id(region_name = 'Phoenix', region_source = 'MPA', key = key)
 
-get_raster(spatial_resolution = 'low',
-           temporal_resolution = 'yearly',
-           group_by = 'flag',
+get_raster(spatial_resolution = 'LOW',
+           temporal_resolution = 'YEARLY',
+           group_by = 'FLAG',
            date_range = '2015-01-01,2015-06-01',
            region = code_mpa$id[1],
-           region_source = 'mpa',
+           region_source = 'MPA',
            key = key)
 ```
 
@@ -315,12 +315,12 @@ organizations (RFMO) that manage tuna and tuna-like species. These include `"ICC
 `"IATTC"`,`"IOTC"`, `"CCSBT"` and `"WCPFC"`.
 
 ```{r example_map_5, eval=T}
-get_raster(spatial_resolution = 'low',
-           temporal_resolution = 'daily',
-           group_by = 'flag',
+get_raster(spatial_resolution = 'LOW',
+           temporal_resolution = 'DAILY',
+           group_by = 'FLAG',
            date_range = '2021-01-01,2021-01-15',
            region = 'ICCAT',
-           region_source = 'rfmo',
+           region_source = 'RFMO',
            key = key)
 ```
 


### PR DESCRIPTION
This PR updates the `get_raster` function so that v2 functionality works with v3 of the APIs.

Main changes:

- changed `csv` parameter to `CSV`
- changed the url path for pulling region ids from `user-context-layers` to `context-layers`
- for consistency with other API parameters, capitalized all references to EEZ, MPA, and RFMO
- Updated raster section README.Rmd so it was compatible with v3.

This PR does not add any functionality not available in v2