### PR TITLE
Updates migration guide link and a disclaimer about missing API from V3

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,12 +6,6 @@ check [the API documentation](https://globalfishingwatch.org/our-apis/documentat
 and the [migration guide](https://globalfishingwatch.org/our-apis/assets/GFW_API.Migration_Guide_to_v3.pdf)
 if anything is new or missing.
 
-Some [APIs](https://globalfishingwatch.org/our-apis/documentation#version-3-api) were not implemented because they were primarily designed for a frontend application rather than a library. These APIs are:
-* /v3/4wings/generate-png
-* /v3/4wings/tile/:type/:z/:x/:y
-* /v3/4wings/interaction/{z}/{x}/{y}/{cells}
-* /v3/4wings/bins/:z
-
 ## Endpoints
 
 - Same endpoints as in v1.1.0
@@ -24,6 +18,11 @@ Some [APIs](https://globalfishingwatch.org/our-apis/documentation#version-3-api)
   region 
   + `get_last_report()` to check status of last API request to `get_raster()`
   
+**Note:** Some [APIs](https://globalfishingwatch.org/our-apis/documentation#version-3-api) were not implemented because they were primarily designed for a frontend application rather than for data download. These APIs are:
+* /v3/4wings/generate-png
+* /v3/4wings/tile/:type/:z/:x/:y
+* /v3/4wings/interaction/{z}/{x}/{y}/{cells}
+* /v3/4wings/bins/:z
 
 ## Major changes and new features
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,8 +3,14 @@
 __`gfwr` was updated to work with version 3 of our APIs.__ This results in various breaking changes in 
 parameter names and output formats. We aim to list here the major modifications but please also
 check [the API documentation](https://globalfishingwatch.org/our-apis/documentation#version-3-api)
-and the [migration guide](https://drive.google.com/file/d/1xPXhG6tj3132wHvCLu0OwwgKV7NtbuFI/view?usp=drive_link)
+and the [migration guide](https://globalfishingwatch.org/our-apis/assets/GFW_API.Migration_Guide_to_v3.pdf)
 if anything is new or missing.
+
+Some [APIs](https://globalfishingwatch.org/our-apis/documentation#version-3-api) were not implemented because they were primarily designed for a frontend application rather than a library. These APIs are:
+* /v3/4wings/generate-png
+* /v3/4wings/tile/:type/:z/:x/:y
+* /v3/4wings/interaction/{z}/{x}/{y}/{cells}
+* /v3/4wings/bins/:z
 
 ## Endpoints
 


### PR DESCRIPTION
* Fixes link to API v3 migration guide
* Clarifies which API won't be included in the package but they are available as part of V3. For internal reference, that is also described in[ this Notion page](https://www.notion.so/globalfishingwatch/APIs-SDK-gfwr-and-Python-41768965e7b24ff1a0f804ba6d0b09e7)
* 