### PR TITLE
Enable silent reading of CSV-data

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,7 @@ Description: This package connects to several Global Fishing Watch APIs to get v
 License: Apache License (>= 2)
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2
 Imports: 
     dplyr,
     geojsonsf,

--- a/R/get_last_report.R
+++ b/R/get_last_report.R
@@ -3,6 +3,7 @@
 #'
 #' @name get_last_report
 #' @param key Authorization token. Can be obtained with `gfw_auth()` function
+#' @param show_col_types Boolean. Whether to show the column specification when reading the downloaded CSV.
 #' @importFrom httr2 request
 #' @importFrom httr2 req_headers
 #' @importFrom httr2 req_error
@@ -31,7 +32,7 @@
 #' get_last_report(key = gfw_auth())
 #' }
 #'
-get_last_report <- function(key = gfw_auth()) {
+get_last_report <- function(key = gfw_auth(), show_col_types = TRUE) {
 
   # Format request
   endpoint <- httr2::request("https://gateway.api.globalfishingwatch.org/v3/4wings/last-report") %>%
@@ -61,7 +62,7 @@ get_last_report <- function(key = gfw_auth()) {
 
         # unzip zip file and extract .csv
         file <- unz(temp, names[grepl(".csv$", names)])
-        return(readr::read_csv(file))
+        return(readr::read_csv(file, show_col_types = show_col_types))
 
         }
 

--- a/R/get_raster.R
+++ b/R/get_raster.R
@@ -13,6 +13,7 @@
 #' Marine Regions Geographic Identifier or EEZ code).
 #' @param region_source source of the region ('EEZ','MPA', 'RFMO' or 'USER_SHAPEFILE')
 #' @param key Authorization token. Can be obtained with `gfw_auth()` function
+#' @param show_col_types Boolean. Whether to show the column specification when reading the downloaded CSV.
 #' @param print_request Boolean. Whether to print the request, for debugging
 #' purposes. When contacting the GFW team it will be useful to send this string
 #' @importFrom readr read_csv
@@ -63,6 +64,7 @@ get_raster <- function(spatial_resolution = NULL,
                        region = NULL,
                        region_source = NULL,
                        key = gfw_auth(),
+                       show_col_types = TRUE,
                        print_request = FALSE) {
   date_range <- paste(start_date, end_date, sep = ",")
   # Endpoint
@@ -123,5 +125,5 @@ if (is.null(region_source)) stop("region_source and region params are required")
 
   # unzip zip file and extract .csv
   file <- unz(temp, names[grepl(".csv$", names)])
-  return(readr::read_csv(file))
+  return(readr::read_csv(file, show_col_types = show_col_types))
 }

--- a/man/get_last_report.Rd
+++ b/man/get_last_report.Rd
@@ -4,10 +4,12 @@
 \alias{get_last_report}
 \title{Base function to get status of last report generated}
 \usage{
-get_last_report(key = gfw_auth())
+get_last_report(key = gfw_auth(), show_col_types = TRUE)
 }
 \arguments{
 \item{key}{Authorization token. Can be obtained with \code{gfw_auth()} function}
+
+\item{show_col_types}{Boolean. Whether to show the column specification when reading the downloaded CSV.}
 }
 \description{
 Function to check the status of the last API request sent with get_raster().

--- a/man/get_raster.Rd
+++ b/man/get_raster.Rd
@@ -14,6 +14,7 @@ get_raster(
   region = NULL,
   region_source = NULL,
   key = gfw_auth(),
+  show_col_types = TRUE,
   print_request = FALSE
 )
 }
@@ -39,6 +40,8 @@ Marine Regions Geographic Identifier or EEZ code).}
 \item{region_source}{source of the region ('EEZ','MPA', 'RFMO' or 'USER_SHAPEFILE')}
 
 \item{key}{Authorization token. Can be obtained with \code{gfw_auth()} function}
+
+\item{show_col_types}{Boolean. Whether to show the column specification when reading the downloaded CSV.}
 
 \item{print_request}{Boolean. Whether to print the request, for debugging
 purposes. When contacting the GFW team it will be useful to send this string}


### PR DESCRIPTION
Convenient in loops to avoid cluttering the console. Implemented by adding show_col_types argument in `get_raster()` and `get_last_report().