### PR TITLE
Update gfw_region_id.R

### DIFF
--- a/R/gfw_region_id.R
+++ b/R/gfw_region_id.R
@@ -34,6 +34,10 @@ gfw_regions <- function(region_source = "EEZ",
       httr2::resp_body_json(.) %>%
       dplyr::bind_rows()
     if (region_source == "EEZ") {
+
+      # Make data available
+      utils::data("marine_regions", package = "gfwr", envir = environment())
+
       result <- marine_regions %>%
         dplyr::rename(id = MRGID,
                       label = name)
@@ -84,6 +88,10 @@ gfw_region_id <- function(region = NULL,
     dplyr::bind_rows() %>%
     dplyr::relocate("id")
   if (region_source == "EEZ") {
+
+    # Make data available
+    utils::data("marine_regions", package = "gfwr", envir = environment())
+
     result <- marine_regions %>%
       dplyr::rename(id = MRGID,
                     label = name,


### PR DESCRIPTION
The marine_regions data object has been added to access the EEZ code data but because it is lazy loaded it fails if you use the namespace notation (ie gfwr::) without attaching the whole package.

This PR adds utils::data("marine_regions",  package = "gfwr", envir = environment()) to fix the issue

Closes #224 