### PR TITLE
enhance vessel info includes handling, documentation, and response parsing

### DIFF
--- a/R/gfw_vessel_info.R
+++ b/R/gfw_vessel_info.R
@@ -1,3 +1,4 @@
+
 #' Base function to get vessel information from API and convert response to tibble
 #'
 #' @param query When `search_type = "search"`, a length-1 vector with the identity
@@ -6,12 +7,23 @@
 #' @param search_type Type of vessel search to perform. Can be `"search"` (the default)
 #' or `"id"`. (Note:`"advanced"` and `"basic"` are no longer in use as of gfwr 2.0.0.).
 #' @param ids When `search_type = "id"`, a vector with the `vesselId` of interest.
-#' @param includes Enhances the response with new information, defaults to include all.
+#' @param includes Optional. Enhances the response with additional
+#' information depending on the selected `search_type`.
+#'
+#' When `search_type = "search"`, supported values are:
 #' \describe{
 #' \item{`"OWNERSHIP"`}{returns ownership information}
-#' \item{`"AUTHORIZATIONS"`}{lists public authorizations for that vessel}
+#' \item{`"AUTHORIZATIONS"`}{lists public authorizations for the vessel}
 #' \item{`"MATCH_CRITERIA"`}{adds information about the reason why a vessel is returned}
 #' }
+#'
+#' When `search_type = "id"`, supported values are:
+#' \describe{
+#' \item{`"POTENTIAL_RELATED_SELF_REPORTED_INFO"`}{returns potential related self-reported information.}
+#' }
+#'
+#' If `includes` is not provided, all supported values for the selected
+#' `search_type` will be requested.
 #' @param match_fields Optional. Allows to filter by `matchFields` levels.
 #' Possible values: `"SEVERAL_FIELDS"`, `"NO_MATCH"`, `"ALL"`. Incompatible with `where`.
 #' @param registries_info_data when `search_type == "id"`, gets all the registry
@@ -80,9 +92,7 @@ gfw_vessel_info <- function(query = NULL,
                             where = NULL,
                             search_type = "search",
                             ids = NULL,
-                            includes = c("AUTHORIZATIONS",
-                                         "OWNERSHIP",
-                                         "MATCH_CRITERIA"),
+                            includes = NULL,
                             match_fields = NULL,
                             registries_info_data = c("ALL"),
                             key = gfw_auth(),
@@ -94,6 +104,10 @@ gfw_vessel_info <- function(query = NULL,
     warning("basic or advanced search are no longer in use. Options are 'search' or 'id'")
     search_type <- "search"
   }
+
+  # Validate includes ---------------------------------------------------------
+
+  includes <- validate_gfw_vessel_info_includes(includes = includes, search_type = search_type)
 
   #endpoint <- gfw_identity_endpoint(
     #search_type = search_type,
@@ -146,13 +160,13 @@ gfw_vessel_info <- function(query = NULL,
     }
     path_append <- "vessels/search"
 
-    #format includes
-    if (!is.null(includes)) {
-      incl <- vector_to_array(includes, type = "includes")
-      args <- c(args, incl)
-      }
-    }
+  }
 
+  # format includes
+  if (!is.null(includes)) {
+    incl <- vector_to_array(includes, type = "includes")
+    args <- c(args, incl)
+  }
 
   endpoint <- base %>%
     httr2::req_url_path_append(path_append) %>%
@@ -248,7 +262,7 @@ gfw_vessel_info <- function(query = NULL,
     }
   # 4/8 registryOwners #has all records with and without registry but may have a different
   #dimension than registryInfo due to lack of data
-  if ("OWNERSHIP" %in% includes) {
+  if (any(purrr::map_lgl(all_entries, \(x) !is.null(x[['registryOwners']])))) {
   registryOwners <- purrr::map(all_entries, purrr::pluck, "registryOwners") %>%
     unlist(recursive = FALSE) %>%
     purrr::map(., tibble::tibble) %>%
@@ -257,7 +271,7 @@ gfw_vessel_info <- function(query = NULL,
     # dplyr::select(-`<list>`)
 }
   # 5/8 registryPublicAuthorizations
-  if ("AUTHORIZATIONS" %in% includes) {
+  if (any(purrr::map_lgl(all_entries, \(x) !is.null(x[['registryPublicAuthorizations']])))) {
   registryPublicAuthorizations <- purrr::map(all_entries, purrr::pluck, 'registryPublicAuthorizations') %>%
     unlist(recursive = F) %>%
     purrr::map(., tibble::tibble) %>%
@@ -268,7 +282,7 @@ gfw_vessel_info <- function(query = NULL,
   }
 
   # matchCriteria
-  if ("MATCH_CRITERIA" %in% includes) {
+  if (any(purrr::map_lgl(all_entries, \(x) !is.null(x[['matchCriteria']])))) {
   matchCriteria <- purrr::map(all_entries, purrr::pluck, 'matchCriteria') %>%
     unlist(recursive = F) %>%
     purrr::map(., tibble::tibble) %>%
@@ -314,4 +328,54 @@ gfw_vessel_info <- function(query = NULL,
     )
 
   return(output)
+}
+
+#' Validate `includes` for vessel info queries
+#'
+#' @param includes Character vector of includes requested.
+#' @param search_type Type of vessel search to performed by [gfw_vessel_info()].
+#'
+#' @return A normalized character vector of validated include values.
+#'
+#' @name validate_gfw_vessel_info_includes
+#' @keywords internal
+#' @noRd
+validate_gfw_vessel_info_includes <- function(includes = NULL, search_type = "search") {
+  search_includes <- c(
+    "AUTHORIZATIONS",
+    "OWNERSHIP",
+    "MATCH_CRITERIA"
+  )
+
+  id_includes <- c(
+    "POTENTIAL_RELATED_SELF_REPORTED_INFO"
+  )
+
+  allowed_includes <- switch(search_type,
+    search = search_includes,
+    id = id_includes
+  )
+
+  if (is.null(includes)) {
+    includes <- allowed_includes
+  }
+
+  includes <- trimws(toupper(includes))
+
+  invalid_includes <- setdiff(includes, allowed_includes)
+
+  if (length(invalid_includes) > 0) {
+    rlang::abort(
+      c(
+        "Invalid `includes` value(s).",
+        x = glue::glue_collapse(invalid_includes, sep = ", "),
+        i = glue::glue(
+          "`search_type = '{search_type}'` only supports: {glue::glue_collapse(allowed_includes, sep = ', ')}"
+        )
+      ),
+      class = "gfw_vessel_info_invalid_includes"
+    )
+  }
+
+  includes
 }

--- a/R/gfw_vessel_info.R
+++ b/R/gfw_vessel_info.R
@@ -1,41 +1,22 @@
 #' Base function to get vessel information from API and convert response to tibble
 #'
+#' @param search_type Type of vessel search to perform. Can be `"search"` (the
+#' default) to search for identity markers or `"id"` to search per `vesselId`.
+#' (Note:`"advanced"` and `"basic"` are no longer in use as of `gfwr 2.0.0.`).
 #' @param query When `search_type = "search"`, a length-1 vector with the identity
-#' variable of interest, MMSI, IMO, call sign or ship name.
+#' variable of interest, MMSI, IMO, call sign or ship name. A search by vessel
+#' name will return fuzzy results to account for variation in vessel names and
+#' potential misspellings
 #' @param where When `search_type = "search"`, an SQL expression to find the vessel of interest.
-#' @param search_type Type of vessel search to perform. Can be `"search"` (the default)
-#' or `"id"`. (Note:`"advanced"` and `"basic"` are no longer in use as of gfwr 2.0.0.).
-#' @param ids When `search_type = "id"`, a vector with the `vesselId` of interest.
+#' @param ids When `search_type = "id"`, a vector with one or more `vesselId`s
+#' of interest.
 #' @param includes Optional. Enhances the response with additional
-#' information depending on the selected `search_type`.
-#'
-#' When `search_type = "search"`, supported values are:
-#' \describe{
-#' \item{`"OWNERSHIP"`}{returns ownership information}
-#' \item{`"AUTHORIZATIONS"`}{lists public authorizations for the vessel}
-#' \item{`"MATCH_CRITERIA"`}{adds information about the reason why a vessel is returned}
-#' }
-#'
-#' When `search_type = "id"`, supported values are:
-#' \describe{
-#' \item{`"POTENTIAL_RELATED_SELF_REPORTED_INFO"`}{
-#' Returns potential related self-reported vessel information.
-#'
-#' This include provides related `vessel ids` identified through
-#' matching with vessel registry records. It represents Global Fishing Watch's
-#' best estimate for linking AIS (self-reported) vessel positions to Vessel
-#' Identity information derived from public registries.
-#'
-#' See how the Vessel API is used in the Vessel Viewer:
-#' \url{https://globalfishingwatch.org/our-apis/assets/2024_Vessel_Viewer_and_APIs_behind_It.pdf}.
-#' }
-#' }
-#'
-#' If `includes` is not provided, all supported values for the selected
-#' `search_type` will be requested.
+#' information depending on the selected `search_type`. If not specified, all
+#' supported values for the selected `search_type` will be returned. See
+#' __Details__ below
 #'
 #' @param match_fields Optional. Allows to filter by `matchFields` levels.
-#' Possible values: `"SEVERAL_FIELDS"`, `"NO_MATCH"`, `"ALL"`. Incompatible with `where`.
+#' Possible values: `"SEVERAL_FIELDS"`, `"NO_MATCH"`, `"ALL"`. Incompatible with `where`
 #' @param registries_info_data when `search_type == "id"`, gets all the registry
 #' objects, only the delta or the latest.
 #' \describe{
@@ -59,48 +40,56 @@
 #' @importFrom tibble enframe
 #'
 #' @details
-#' When `search_type = "search"` the search takes basic identity features like
+#' - When `search_type = "search"` the search takes basic identity features like
 #' MMSI, IMO, callsign, shipname as inputs, using parameter `"query"`. For more advanced
 #' SQL searches, use parameter `"where"`. You can combine logic operators like `AND`,
-#' `OR`, `=`, `>=` , <, `LIKE` (for fuzzy matching). The `id` search allows the user
-#' to search using a GFW `vesselId`.
+#' `OR`, `=`, `>=` , <, `LIKE` (for fuzzy matching).
+#'
+#' - Parameter __`includes`__: When `search_type = "search"`, supported values are:
+#' \describe{
+#' \item{`"OWNERSHIP"`}{returns ownership information}
+#' \item{`"AUTHORIZATIONS"`}{lists public authorizations for the vessel}
+#' \item{`"MATCH_CRITERIA"`}{adds information about the reason why a vessel is
+#' returned. This provides related `vesselId`s identified through
+#' matching with vessel registry records and represents Global Fishing Watch's
+#' best estimate for linking AIS (self-reported) vessel positions to Vessel
+#' Identity information derived from public registries.}
+#' }
+#' When `search_type = "id"`, the supported value is
+#' `"POTENTIAL_RELATED_SELF_REPORTED_INFO"` and will returns all potential
+#' related self-reported vessel information mentioned above.
+#'
+#' @references Park, J., Van Osdel, J., Turner, J., Farthing, C.M., Miller, N.A.,
+#' Linder, H.L., Ortuño Crespo, G., Carmine, G., Kroodsma, D.A., 2023. Tracking
+#' elusive and shifting identities of the global fishing fleet. Science Advances
+#' 9, eabp8200. [https://doi.org/10.1126/sciadv.abp8200](https://doi.org/10.1126/sciadv.abp8200)
+#' @seealso
+#' For more details check the [Vessel identity vignette](https://globalfishingwatch.github.io/gfwr/articles/identity.html)
+#'
+#' See also how the Vessel API is used in [Vessel Viewer](https://globalfishingwatch.org/our-apis/assets/2024_Vessel_Viewer_and_APIs_behind_It.pdf)
 #'
 #' @examples
 #' \dontrun{
 #' library(gfwr)
 #'
-#' # Simple searches, using includes
+#' # Simple search
 #'
 #' gfw_vessel_info(query = 224224000, search_type = "search")
 #'
 #' # Advanced search with where instead of query:
-#'
 #' gfw_vessel_info(where = "ssvid = '441618000' OR imo = '9047271'",
-#' search_type = "search")
+#'                 search_type = "search")
 #'
 #'  # Vessel id search
 #'
 #'  gfw_vessel_info(search_type = "id",
 #'  ids = c("8c7304226-6c71-edbe-0b63-c246734b3c01",
 #'  "6583c51e3-3626-5638-866a-f47c3bc7ef7c"))
-#'
-#'  all <- gfw_vessel_info(search_type = "id",
-#'  ids = c("8c7304226-6c71-edbe-0b63-c246734b3c01"),
-#'  registries_info_data = c("ALL"))
-#'
-#'  none <- gfw_vessel_info(search_type = "id",
-#'  ids = c("8c7304226-6c71-edbe-0b63-c246734b3c01"),
-#'  registries_info_data = c("NONE"))
-#'
-#'  delta <- gfw_vessel_info(search_type = "id",
-#'  ids = c("8c7304226-6c71-edbe-0b63-c246734b3c01"),
-#'  registries_info_data = c("DELTA"))
-#'
 #'  }
 #' @export
-gfw_vessel_info <- function(query = NULL,
+gfw_vessel_info <- function(search_type = "search",
+                            query = NULL,
                             where = NULL,
-                            search_type = "search",
                             ids = NULL,
                             includes = NULL,
                             match_fields = NULL,

--- a/R/gfw_vessel_info.R
+++ b/R/gfw_vessel_info.R
@@ -1,4 +1,3 @@
-
 #' Base function to get vessel information from API and convert response to tibble
 #'
 #' @param query When `search_type = "search"`, a length-1 vector with the identity
@@ -19,11 +18,22 @@
 #'
 #' When `search_type = "id"`, supported values are:
 #' \describe{
-#' \item{`"POTENTIAL_RELATED_SELF_REPORTED_INFO"`}{returns potential related self-reported information.}
+#' \item{`"POTENTIAL_RELATED_SELF_REPORTED_INFO"`}{
+#' Returns potential related self-reported vessel information.
+#'
+#' This include provides related `vessel ids` identified through
+#' matching with vessel registry records. It represents Global Fishing Watch's
+#' best estimate for linking AIS (self-reported) vessel positions to Vessel
+#' Identity information derived from public registries.
+#'
+#' See how the Vessel API is used in the Vessel Viewer:
+#' \url{https://globalfishingwatch.org/our-apis/assets/2024_Vessel_Viewer_and_APIs_behind_It.pdf}.
+#' }
 #' }
 #'
 #' If `includes` is not provided, all supported values for the selected
 #' `search_type` will be requested.
+#'
 #' @param match_fields Optional. Allows to filter by `matchFields` levels.
 #' Possible values: `"SEVERAL_FIELDS"`, `"NO_MATCH"`, `"ALL"`. Incompatible with `where`.
 #' @param registries_info_data when `search_type == "id"`, gets all the registry


### PR DESCRIPTION
This:
- Support `search_type`-aware `includes` handling in `gfw_vessel_info()`
- Change `includes` default to `NULL` and derive supported values dynamically based on `search_type`
- Add `validate_gfw_vessel_info_includes()` helper to normalize and validate requested `includes`
- Update `gfw_vessel_info()` documentation to clearly describe supported `includes` per search type
- Refactor includes formatting so it is applied consistently for both `"search"` and `"id"` queries
- Improve response parsing to safely handle missing `registryOwners`, `registryPublicAuthorizations`, and `matchCriteria`
- Closes #239